### PR TITLE
[datetime] Handle wrong timezone offset

### DIFF
--- a/grimoirelab/toolkit/datetime.py
+++ b/grimoirelab/toolkit/datetime.py
@@ -67,7 +67,8 @@ def datetime_to_utc(ts):
 
     Returns the given datetime object converted to a date with
     UTC+0 timezone. For naive datetimes, it will be assumed that
-    they are in UTC+0.
+    they are in UTC+0. When the timezone is wrong, UTC+0 will
+    be set as default (using `dateutil.tz.tzutc` object).
 
     :param dt: timestamp to convert
 
@@ -83,7 +84,14 @@ def datetime_to_utc(ts):
     if not ts.tzinfo:
         ts = ts.replace(tzinfo=dateutil.tz.tzutc())
 
-    return ts.astimezone(dateutil.tz.tzutc())
+    try:
+        ts = ts.astimezone(dateutil.tz.tzutc())
+    except ValueError:
+        logger.warning("Date %s str does not have a valid timezone", ts)
+        logger.warning("Date converted to UTC removing timezone info")
+        ts = ts.replace(tzinfo=dateutil.tz.tzutc()).astimezone(dateutil.tz.tzutc())
+
+    return ts
 
 
 def str_to_datetime(ts):

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -182,6 +182,11 @@ class TestStrToDatetime(unittest.TestCase):
         self.assertIsInstance(date, datetime.datetime)
         self.assertEqual(date, expected)
 
+    def test_invalid_unixtime_to_datetime(self):
+        """Check whether it fails with an invalid unixtime."""
+
+        self.assertRaises(InvalidDateError, unixtime_to_datetime, '2017-07-24')
+
     def test_invalid_date(self):
         """Check whether it fails with an invalid date."""
 

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -20,6 +20,7 @@
 #
 
 import datetime
+import sys
 import unittest
 
 import dateutil
@@ -70,6 +71,23 @@ class TestDatetimeToUTC(unittest.TestCase):
         expected = datetime.datetime(2001, 12, 1, 23, 15, 32,
                                      tzinfo=dateutil.tz.tzutc())
         utc = datetime_to_utc(date)
+        self.assertIsInstance(utc, datetime.datetime)
+        self.assertEqual(utc, expected)
+
+    def test_invalid_timezone(self):
+        """Check whether an invalid timezone is converted to UTC+0"""
+
+        # Python 3.6 does not put any restriction on the offset range.
+        # Thus, this test is valid only for prior Python versions.
+        if sys.version_info.major == 3 and sys.version_info.minor == 6:
+            return
+
+        date = datetime.datetime(2001, 12, 1, 23, 15, 32,
+                                 tzinfo=dateutil.tz.tzoffset(None, -3407))
+        expected = datetime.datetime(2001, 12, 1, 23, 15, 32,
+                                     tzinfo=dateutil.tz.tzutc())
+        utc = datetime_to_utc(date)
+
         self.assertIsInstance(utc, datetime.datetime)
         self.assertEqual(utc, expected)
 


### PR DESCRIPTION
This patch allows to handle dates with wrong timezone offsets (e.g., -3402). The wrong timezone is replaced by UTC+0.