### PR TITLE
[dependency] Update python-dateutil to 2.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-dateutil>=2.6.0
+python-dateutil>=2.8.0

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(name="grimoirelab-toolkit",
           'grimoirelab_toolkit',
       ],
       install_requires=[
-          'python-dateutil>=2.6.0'
+          'python-dateutil>=2.8.0'
       ],
       cmdclass=cmdclass,
       zip_safe=False)

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -20,7 +20,6 @@
 #
 
 import datetime
-import sys
 import unittest
 
 import dateutil
@@ -68,23 +67,6 @@ class TestDatetimeToUTC(unittest.TestCase):
         expected = datetime.datetime(2001, 12, 1, 23, 15, 32,
                                      tzinfo=dateutil.tz.tzutc())
         utc = datetime_to_utc(date)
-        self.assertIsInstance(utc, datetime.datetime)
-        self.assertEqual(utc, expected)
-
-    def test_invalid_timezone(self):
-        """Check whether an invalid timezone is converted to UTC+0"""
-
-        # Python 3.6 does not put any restriction on the offset range.
-        # Thus, this test is valid only for prior Python versions.
-        if sys.version_info.major == 3 and sys.version_info.minor == 6:
-            return
-
-        date = datetime.datetime(2001, 12, 1, 23, 15, 32,
-                                 tzinfo=dateutil.tz.tzoffset(None, -3407))
-        expected = datetime.datetime(2001, 12, 1, 23, 15, 32,
-                                     tzinfo=dateutil.tz.tzutc())
-        utc = datetime_to_utc(date)
-
         self.assertIsInstance(utc, datetime.datetime)
         self.assertEqual(utc, expected)
 


### PR DESCRIPTION
This PR updates the dependency of the python-dateutil package to 2.8.0 in the setup.py and requirements.txt. The test `test_invalid_timezone` has been removed since it is not needed anymore. The change was needed due to the fact that the version 2.8.0 allows to deal with negative timezone offsets, something that wasn't handled before.