### PR TITLE
[travis] Update coverage source param

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 script:
   - flake8 .
   - cd tests
-  - coverage run --source=grimoirelab run_tests.py
+  - coverage run --source=grimoirelab_toolkit run_tests.py
 
 after_success:
   - coveralls


### PR DESCRIPTION
This code updates the coverage source param, which now is `grimoirelab_toolkit`.