### PR TITLE
[setup] Fix format type for long description of package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,16 +34,9 @@ here = os.path.abspath(os.path.dirname(__file__))
 readme_md = os.path.join(here, 'README.md')
 version_py = os.path.join(here, 'grimoirelab_toolkit', '_version.py')
 
-# Pypi wants the description to be in reStrcuturedText, but
-# we have it in Markdown.
-try:
-    import pypandoc
-    long_description = pypandoc.convert(readme_md, 'rst')
-except (IOError, ImportError):
-    print("Warning: pypandoc module not found, or pandoc not installed. "
-          "Using md instead of rst")
-    with codecs.open(readme_md, encoding='utf-8') as f:
-        long_description = f.read()
+# Get the package description from the README.md file
+with codecs.open(readme_md, encoding='utf-8') as f:
+    long_description = f.read()
 
 with codecs.open(version_py, 'r', encoding='utf-8') as fd:
     version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
@@ -72,6 +65,7 @@ cmdclass = {'test': TestCommand}
 setup(name="grimoirelab-toolkit",
       description="Toolkit of common functions used across GrimoireLab",
       long_description=long_description,
+      long_description_content_type='text/markdown',
       url="https://github.com/chaoss/grimoirelab-toolkit",
       version=version,
       author="Bitergia",


### PR DESCRIPTION
Pypi requires that the format of the long description for a package is detailed in the variable `long_description_content_type`, in setup.py. Since it now supports Markdown, the conversion to
reST is not needed anymore.