### PR TITLE
[datetime] Handle dates with large offsets

### DIFF
--- a/grimoirelab_toolkit/datetime.py
+++ b/grimoirelab_toolkit/datetime.py
@@ -136,11 +136,21 @@ def str_to_datetime(ts):
 
             if m:
                 dt = parse_datetime(m.group(1))
-                logger.warning("Date %s str does not have a valid timezone", ts)
-                logger.warning("Date converted removing timezone info")
+                logger.warning("Date %s does not have a valid timezone. "
+                               "Date converted removing timezone info", ts)
                 return dt
 
             raise e
+
+        try:
+            # Check that the offset is between -timedelta(hours=24) and
+            # timedelta(hours=24). If it is not the case, convert the
+            # date to UTC and remove the timezone info.
+            _ = dt.astimezone(dateutil.tz.tzutc())
+        except ValueError:
+            logger.warning("Date %s does not have a valid timezone; timedelta not in range. "
+                           "Date converted to UTC removing timezone info", ts)
+            dt = dt.replace(tzinfo=dateutil.tz.tzutc()).astimezone(dateutil.tz.tzutc())
 
         return dt
 

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -161,6 +161,12 @@ class TestStrToDatetime(unittest.TestCase):
         self.assertIsInstance(date, datetime.datetime)
         self.assertEqual(date, expected)
 
+        date = str_to_datetime('Sun, 28 Feb 1999 19:17:37 -7700 (EST)')
+        expected = datetime.datetime(1999, 2, 28, 19, 17, 37,
+                                     tzinfo=dateutil.tz.tzutc())
+        self.assertIsInstance(date, datetime.datetime)
+        self.assertEqual(date, expected)
+
     def test_invalid_unixtime_to_datetime(self):
         """Check whether it fails with an invalid unixtime."""
 


### PR DESCRIPTION
When analyzing https://mail.gnome.org/archives/gtk-list/`, certain message dates are converted by `str_to_datetime` to a datetime obj with no timezone info and a large offset. For instance, the following date: `Sun, 28 Feb 1999 19:17:37 -7700 (EST)` is converted to `datetime.datetime(1999, 2, 28, 19, 17, 37, tzinfo=tzoffset(None, -277200))`. The obtained datetime obj is then evaluated with the `from_date` variable (another datetime obj) in the IF condition at https://github.com/chaoss/grimoirelab-perceval/blob/master/perceval/backends/core/mbox.py#L211. However, for the aforementioned example, this evaluation fails due to `ValueError: offset must be a timedelta strictly between -timedelta(hours=24) and timedelta(hours=24)` (this due to the fact that ` -277200` isn't in the correct range).

This PR proposes to convert the dates to UTC and add the offset if possible. If the offset is not valid (meaning that the statement at https://github.com/chaoss/grimoirelab-toolkit/pull/22/files#diff-81fbaebc7d86ab65852aff3d7a3b5508R117 fails to add the offset), the offset is removed (by the following block https://github.com/chaoss/grimoirelab-toolkit/blob/master/grimoirelab_toolkit/datetime.py#L138).

Tests have been added accordingly.

I tested it with the repos below and the error is gone.
- https://mail.gnome.org/archives/gtk-devel-list/
- https://mail.gnome.org/archives/gtk-list/