### PR TITLE
[tests] Add tests for invalid timezone

### DIFF
--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -74,6 +74,17 @@ class TestDatetimeToUTC(unittest.TestCase):
         self.assertIsInstance(utc, datetime.datetime)
         self.assertEqual(utc, expected)
 
+    def test_invalid_timezone(self):
+        """ Check whether datetime converts to UTC when timezone invalid """
+
+        date = datetime.datetime(2001, 12, 1, 23, 15, 32,
+                                 tzinfo=dateutil.tz.tzoffset(None, 93600))
+        expected = datetime.datetime(2001, 12, 1, 23, 15, 32,
+                                     tzinfo=dateutil.tz.tzutc())
+        utc = datetime_to_utc(date)
+        self.assertIsInstance(utc, datetime.datetime)
+        self.assertEqual(utc, expected)
+
     def test_invalid_datetime(self):
         """Check if it raises an exception on invalid instances."""
 


### PR DESCRIPTION
Coverage was missing for when timezone
might be invalid. Added a test which takes an invalid date
and tries to convert it to UTC. Being invalid, it will trigger
the exception on line 92, remove timezone info and convert to UTC.

Signed-off-by: sevagenv <sevagenv@gmail.com>