### PR TITLE
[poetry] Add setuptools to the build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,5 +44,8 @@ python-dateutil = "^2.8.0"
 [tool.poetry.dev-dependencies]
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = [
+    "poetry>=0.12",
+    "setuptools>=30.3.0,<50"
+]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
This PR adds the setuptools version to the poetry setup configurations. This is needed to fix the `No module named "setuptools"` bug.

https://github.com/chaoss/grimoirelab-perceval/issues/720