### PR TITLE
[gha] Rename workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           name: toolkit-dist
           path: dist
   
-  test:
+  tests:
     needs: [build]
     runs-on: ubuntu-latest
     strategy:
@@ -52,7 +52,7 @@ jobs:
           cd tests && python run_tests.py
   
   release:
-    needs: [test]
+    needs: [tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -70,7 +70,7 @@ jobs:
           body_path: ./releases/${{ steps.tag.outputs.tag }}.md
   
   publish:
-    needs: [test]
+    needs: [tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: build
+name: tests
 
 on: [push, pull_request]
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GrimoireLab Toolkit [![Build Status](https://github.com/chaoss/grimoirelab-toolkit/workflows/build/badge.svg)](https://github.com/chaoss/grimoirelab-toolkit/actions?query=workflow:build+branch:master+event:push) [![Coverage Status](https://img.shields.io/coveralls/chaoss/grimoirelab-toolkit.svg)](https://coveralls.io/r/chaoss/grimoirelab-toolkit?branch=master)
+# GrimoireLab Toolkit [![Build Status](https://github.com/chaoss/grimoirelab-toolkit/workflows/tests/badge.svg)](https://github.com/chaoss/grimoirelab-toolkit/actions?query=workflow:tests+branch:master+event:push) [![Coverage Status](https://img.shields.io/coveralls/chaoss/grimoirelab-toolkit.svg)](https://coveralls.io/r/chaoss/grimoirelab-toolkit?branch=master)
 
 Toolkit of common functions used across GrimoireLab projects.
 


### PR DESCRIPTION
This commit renames the github actions workflows and also rewords the job names to avoid ambiguity. The badge in the README.md is updated accordingly.