### PR TITLE
[tests] Restrict the workflow for a release tag

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,14 @@
 name: tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - '!*.*.*'
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   tests:


### PR DESCRIPTION
This commit adds a rule to restrict the tests workflow to run when a release tag is pushed to the repository.

Whenever the maintainer uses the `publish` command, a release commit and a release tag are pushed. This would trigger the tests workflow twice resulting in redundant workflows in the logs. This change is needed to avoid this.