### PR TITLE
Fix wrong location of metadata files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,9 @@ packages = [
 ]
 
 include = [
-    "AUTHORS",
-    "README.md",
-    "LICENSE",
-    "NEWS"
+    { path = "AUTHORS", format = "sdist" },
+    { path = "NEWS", format = "sdist" },
+    { path = "README.md", format = "sdist" },
 ]
 
 classifiers = [


### PR DESCRIPTION
The metadata files aren't correctly extracted when the package is installed using pip. This is because of the configurations in the pyproject.toml file. This PR corrects it.

Fixes #44 