### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
       - name: Download distribution artifact

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - '**'
     tags:
-      - '!*.*.*'
+      - '!**'
   pull_request:
     branches:
       - '**'
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     name: Python ${{ matrix.python-version }}
     steps:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ URIs/URLs, among other topics.
 
 ## Requirements
 
-* Python >= 3.4
+* Python >= 3.7
 * python3-dateutil >= 2.6
 
 ## Installation

--- a/poetry.lock
+++ b/poetry.lock
@@ -104,8 +104,8 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.6"
-content-hash = "b15f30cc978943f5bcc83ff1ccadaf600e5efc11f6f99c01ac13b6d840660b14"
+python-versions = "^3.7"
+content-hash = "8a4d29e51b2f77566a211978653d001736a5d54816ef3846ef57d108c86bcb4c"
 
 [metadata.files]
 coverage = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 python-dateutil = "^2.8.0"
 
 [tool.poetry.dev-dependencies]

--- a/releases/unreleased/drop-python-3.6-support.yml
+++ b/releases/unreleased/drop-python-3.6-support.yml
@@ -1,0 +1,10 @@
+---
+title: Drop Python 3.6 support
+category: removed
+author: Venu Vardhan Reddy Tekula <venu@chaoss.community>
+issue: null
+notes: >
+    Python 3.6 has reached the end of life in Dec 2021.
+    This means it won't receive any further patches to
+    fix the secutiry issues. So, dropping the support
+    of 3.6 and it now supports Python>=3.7 version only. 


### PR DESCRIPTION
This PR removes the support of Python 3.6 as the support for 3.6 has officially ended on 23 Dec 2021.
https://endoflife.date/python

Python 3.7, 3.8, 3.9 are now supported. The documentation and github action workflows are also updated.

It also updates the condition for restricting the execution of the tests workflow when any tag is pushed to GitHub.