### PR TITLE
[pyproject] Update build system to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,5 @@ flake8 = "^3.9.1"
 coverage = "^5.5"
 
 [build-system]
-requires = [
-    "poetry>=0.12",
-    "setuptools>=30.3.0,<50"
-]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This PR updates the build system in the pyproject file to poetry-core.

The previous build system was 'setuptools<50' which is not PEP 660 compliant and packages could not be installed in editable mode.