### PR TITLE
Update deprecated utcfromtimestamp in Python 3.12

### DIFF
--- a/grimoirelab_toolkit/datetime.py
+++ b/grimoirelab_toolkit/datetime.py
@@ -175,7 +175,7 @@ def unixtime_to_datetime(ut):
         converted into a valid date
     """
     try:
-        dt = datetime.datetime.utcfromtimestamp(ut)
+        dt = datetime.datetime.fromtimestamp(ut, datetime.timezone.utc)
         dt = dt.replace(tzinfo=dateutil.tz.tzutc())
         return dt
     except Exception:

--- a/poetry.lock
+++ b/poetry.lock
@@ -163,4 +163,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "7053aa84b737249a077f3c865fd7df35925c61c6f82c624c88aaf37738258b67"
+content-hash = "5e81a1ce14ad42cec4456faedce7b00f7796bc971219b53a2514dfdc7ada1823"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 python = "^3.9"
 python-dateutil = "^2.8.2"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 flake8 = "^7.1.1"
 coverage = "^7.2.3"
 

--- a/releases/unreleased/deprecated-utcfromtimestamp-updated.yml
+++ b/releases/unreleased/deprecated-utcfromtimestamp-updated.yml
@@ -1,0 +1,8 @@
+---
+title: Deprecated utcfromtimestamp updated
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Class method `utcfromtimestamp` was deprecated in Python 3.12
+  and it recommends using `fromtimestamp` with UTC instead.


### PR DESCRIPTION
This PR updates the method `utcfromtimestamp` to `fromtimestamp` because it has been deprecated since Python 3.12.

https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp