### PR TITLE
Standalone credential resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,89 @@ Field Descriptions
 
 The module uses the [hvac](https://hvac.readthedocs.io/) Python library to interact with HashiCorp Vault.
 
+### `resolve_credentials()` — Unified credential resolution
+
+The `resolve_credentials()` function provides a high-level interface to
+fetch and extract credentials from any supported secrets manager in a single
+call. It handles manager instantiation, authentication, secret retrieval,
+field extraction, and cleanup automatically.
+
+This function is designed to work independently of any CLI framework, making
+it usable from Perceval's `BackendCommand`, KingArthur, or any custom script.
+
+#### Example
+
+```python
+from grimoirelab_toolkit.credential_manager import resolve_credentials
+
+# Bitwarden example
+credentials = resolve_credentials(
+    manager_type='bitwarden',
+    manager_config={
+        'client_id': 'your-client-id',
+        'client_secret': 'your-client-secret',
+        'master_password': 'your-master-password',
+    },
+    item_name='GitHub',
+    field_mapping={'api-token': 'api_token', 'username': 'user'},
+)
+# credentials = {'api_token': 'ghp_...', 'user': 'myuser'}
+
+# HashiCorp example
+credentials = resolve_credentials(
+    manager_type='hashicorp',
+    manager_config={
+        'vault_url': 'https://vault.example.com',
+        'token': 'hvs.your-token',
+    },
+    item_name='secret/my-service',
+    field_mapping={'api_key': 'api_token'},
+)
+```
+
+#### Parameters
+
+- `manager_type` (`str`) — `"bitwarden"` or `"hashicorp"`
+- `manager_config` (`dict`) — Manager-specific authentication credentials (see below)
+- `item_name` (`str`) — Name/path of the secret item in the vault
+- `field_mapping` (`dict[str, str]`) — Maps secret field names to output parameter names
+
+#### Manager config by provider
+
+- **Bitwarden**: `client_id`, `client_secret`, `master_password`
+- **HashiCorp**: `vault_url`, `token`, `certificate` (optional)
+
+#### Return value
+
+A `dict[str, str]` mapping output parameter names to resolved string values.
+Only fields that were found are included in the result. Missing fields
+produce a warning log and are omitted (partial results are valid).
+
+#### Field extraction behavior
+
+Each manager returns secrets in a different format. `resolve_credentials()`
+normalizes the extraction:
+
+- **Bitwarden**: Checks `item['login']` dict first (for username, password),
+  then searches the `item['fields']` array (for custom fields like API tokens).
+- **HashiCorp**: Reads from `secret['data']['data'][field_name]`.
+
+#### Error handling
+
+- Unsupported `manager_type` raises `ValueError`
+- Empty `item_name` raises `ValueError`
+- Secret item not found raises `CredentialNotFoundError`
+- Individual missing fields are skipped with a warning (no error)
+- For Bitwarden, `logout()` is always called in a `finally` block
+
+### Optional dependencies (lazy imports)
+
+The secrets manager providers use lazy imports, so you only need to install
+the dependencies for the provider you actually use:
+
+- **Bitwarden**: requires `bw` CLI on `PATH` (no Python package needed)
+- **HashiCorp**: requires `hvac` (`poetry install --with hashicorp-manager`)
+
 ## License
 
 Licensed under GNU General Public License (GPL), version 3 or later.

--- a/grimoirelab_toolkit/credential_manager/__init__.py
+++ b/grimoirelab_toolkit/credential_manager/__init__.py
@@ -15,16 +15,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-# Author:
-#     Alberto Ferrer Sánchez (alberefe@gmail.com)
 #
 
 from .bw_manager import BitwardenManager
+from .credential_manager import resolve_credentials
 from .exceptions import (
     CredentialManagerError,
     InvalidCredentialsError,
     CredentialNotFoundError,
     BitwardenCLIError,
+    HashicorpVaultError,
 )
 
 __all__ = [
@@ -33,4 +33,6 @@ __all__ = [
     "InvalidCredentialsError",
     "CredentialNotFoundError",
     "BitwardenCLIError",
+    "HashicorpVaultError",
+    "resolve_credentials",
 ]

--- a/grimoirelab_toolkit/credential_manager/credential_manager.py
+++ b/grimoirelab_toolkit/credential_manager/credential_manager.py
@@ -1,0 +1,271 @@
+#
+#
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+import argparse
+import getpass
+import logging
+import os
+import sys
+
+from .secrets_manager_factory import SecretsManagerFactory
+
+CREDENTIAL_MANAGER_LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
+CREDENTIAL_MANAGER_DEBUG_LOG_FORMAT = (
+    "[%(asctime)s - %(name)s - %(levelname)s] - %(message)s"
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_secret(
+    secrets_manager_name: str, service_name: str, credential_name: str
+) -> str:
+    """
+    Retrieve a secret from the secrets manager.
+
+    :param str secrets_manager_name: The name of the secrets manager to be used
+    :param str service_name: The name of the service we want to access
+    :param str credential_name: The name of the credential we want to retrieve
+    :returns: The credential retrieved
+    :rtype: str
+    :raises ValueError: If the secrets manager is not supported or initialization fails
+    """
+    try:
+        if secrets_manager_name == "bitwarden":
+            # Get credentials from environment or prompt user
+            email = os.environ.get("GRIMOIRELAB_BW_EMAIL")
+            password = os.environ.get("GRIMOIRELAB_BW_PASSWORD")
+
+            if not email or not password:
+                if not email:
+                    email = input("Bitwarden email: ")
+                if not password:
+                    password = getpass.getpass("Bitwarden master password: ")
+
+            manager = SecretsManagerFactory.get_bitwarden_manager(email, password)
+            return manager.get_secret(service_name, credential_name)
+
+        elif secrets_manager_name == "hashicorp":
+            # Get credentials from environment or prompt user
+            vault_addr = os.environ.get("GRIMOIRELAB_VAULT_ADDR")
+            token = os.environ.get("GRIMOIRELAB_VAULT_TOKEN")
+            certificate = os.environ.get("GRIMOIRELAB_VAULT_CACERT")
+
+            if not vault_addr or not token or not certificate:
+                if not vault_addr:
+                    vault_addr = input("Please enter vault address: ")
+                if not token:
+                    token = input("Please enter vault token: ")
+                if not certificate:
+                    certificate = input(
+                        "Please enter path to a PEM-encoded CA certificate file: "
+                    )
+
+            manager = SecretsManagerFactory.get_hashicorp_manager(
+                vault_addr, token, certificate
+            )
+            return manager.get_secret(service_name, credential_name)
+
+        else:
+            raise ValueError(f"Unsupported secrets manager: {secrets_manager_name}")
+
+    except Exception as e:
+        logger.error("Error retrieving secret: %s", e)
+        raise
+
+
+SUPPORTED_MANAGERS = ("bitwarden", "hashicorp")
+
+
+def _extract_bitwarden_field(item, field_name):
+    """Extract a field value from a Bitwarden item.
+
+    Searches in the 'login' dict first, then in the 'fields' array.
+
+    :param dict item: The Bitwarden item dictionary
+    :param str field_name: The name of the field to extract
+
+    :returns: The field value or None if not found
+    :rtype: str or None
+    """
+    # Check login fields first (username, password, etc.)
+    login_data = item.get('login', {})
+    if login_data and field_name in login_data:
+        return login_data[field_name]
+
+    # Check custom fields array
+    for field in item.get('fields', []):
+        if field.get('name') == field_name:
+            return field.get('value')
+
+    return None
+
+
+def _extract_hashicorp_field(secret, field_name):
+    """Extract a field value from a HashiCorp Vault secret.
+
+    Reads from secret['data']['data'][field_name].
+
+    :param dict secret: The HashiCorp Vault secret dictionary
+    :param str field_name: The name of the field to extract
+
+    :returns: The field value or None if not found
+    :rtype: str or None
+    """
+    secret_data = secret.get('data', {}).get('data', {})
+    return secret_data.get(field_name)
+
+
+def resolve_credentials(
+    manager_type: str,
+    manager_config: dict,
+    item_name: str,
+    field_mapping: dict[str, str],
+) -> dict[str, str]:
+    """Resolve credentials from a secrets manager.
+
+    Fetches a secret item from the specified secrets manager and extracts
+    the requested fields. This function works independently of any CLI
+    framework, making it usable from any caller (BackendCommand, KingArthur,
+    scripts, etc.).
+
+    :param str manager_type: The secrets manager to use
+        ('bitwarden' or 'hashicorp')
+    :param dict manager_config: Manager-specific authentication config.
+        Bitwarden: {'client_id', 'client_secret', 'master_password'}
+        HashiCorp: {'vault_url', 'token', 'certificate'}
+    :param str item_name: Name/path of the secret item in the vault
+    :param dict field_mapping: Maps secret field names to output parameter
+        names. Example: {'api_key': 'api_token', 'username': 'user'}
+
+    :returns: Dict mapping output parameter names to resolved string values.
+        Only fields that were found are included.
+    :rtype: dict[str, str]
+
+    :raises ValueError: If manager_type is unsupported or item_name is empty
+    :raises CredentialNotFoundError: If the secret item is not found
+    :raises CredentialManagerError: If manager authentication fails
+    """
+    if manager_type not in SUPPORTED_MANAGERS:
+        raise ValueError(
+            f"Unsupported secrets manager: '{manager_type}'. "
+            f"Supported: {', '.join(SUPPORTED_MANAGERS)}"
+        )
+
+    if not item_name:
+        raise ValueError("item_name must be non-empty")
+
+    if not field_mapping:
+        return {}
+
+    result = {}
+
+    if manager_type == 'bitwarden':
+        manager = SecretsManagerFactory.get_bitwarden_manager(
+            manager_config['client_id'],
+            manager_config['client_secret'],
+            manager_config['master_password'],
+        )
+        manager.login()
+        try:
+            item = manager.get_secret(item_name)
+            for secret_field, output_param in field_mapping.items():
+                value = _extract_bitwarden_field(item, secret_field)
+                if value is None:
+                    logger.warning(
+                        "Field '%s' not found in Bitwarden item '%s'",
+                        secret_field, item_name,
+                    )
+                    continue
+                result[output_param] = value
+        finally:
+            manager.logout()
+
+    elif manager_type == 'hashicorp':
+        manager = SecretsManagerFactory.get_hashicorp_manager(
+            manager_config['vault_url'],
+            manager_config['token'],
+            manager_config.get('certificate'),
+        )
+        secret = manager.get_secret(item_name)
+        for secret_field, output_param in field_mapping.items():
+            value = _extract_hashicorp_field(secret, secret_field)
+            if value is None:
+                logger.warning(
+                    "Field '%s' not found in HashiCorp secret '%s'",
+                    secret_field, item_name,
+                )
+                continue
+            result[output_param] = value
+
+    return result
+
+
+def configure_logging(debug=False):
+    """Configure credential_manager logging
+
+    The function configures the log messages produced by Credential_manager.
+    By default, log messages are sent to stderr. Set the parameter
+    `debug` to activate the debug mode.
+
+    :param bool debug: set the debug mode
+    """
+    if not debug:
+        logging.basicConfig(level=logging.INFO, format=CREDENTIAL_MANAGER_LOG_FORMAT)
+        logging.getLogger("requests").setLevel(logging.WARNING)
+        logging.getLogger("urllib3").setLevel(logging.WARNING)
+    else:
+        logging.basicConfig(
+            level=logging.DEBUG, format=CREDENTIAL_MANAGER_DEBUG_LOG_FORMAT
+        )
+
+
+def main():
+    """
+    Main entry point for the command line interface.
+    Parses arguments and retrieves secrets using the appropriate manager.
+
+    :returns: None
+    :rtype: None
+    """
+    parser = argparse.ArgumentParser(
+        description="Retrieve a secret from a specified secrets manager."
+    )
+    parser.add_argument(
+        "manager",
+        choices=["bitwarden", "hashicorp"],
+        help="The name of the secrets manager to use.",
+    )
+    parser.add_argument(
+        "service", help="The name of the service for which to retrieve the credential."
+    )
+    parser.add_argument("credential", help="The name of the credential to retrieve.")
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+
+    args = parser.parse_args()
+
+    configure_logging(args.debug)
+
+    logging.info("Starting credental manager.")
+
+    try:
+        secret = get_secret(args.manager, args.service, args.credential)
+        return secret
+    except Exception as e:
+        logger.error("Failed to retrieve secret: %s", e)
+        sys.exit(1)

--- a/grimoirelab_toolkit/credential_manager/secrets_manager_factory.py
+++ b/grimoirelab_toolkit/credential_manager/secrets_manager_factory.py
@@ -1,0 +1,95 @@
+#
+#
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+import logging
+
+from .exceptions import HashicorpVaultError
+
+logging.basicConfig(
+    level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+class SecretsManagerFactory:
+    """Factory for creating secrets manager instances.
+
+    This class defines static methods to create instances of different
+    secrets manager implementations. The workflow is:
+
+    bw_manager = SecretsManagerFactory.get_bitwarden_manager(client_id, client_secret, master_password)
+    hc_manager = SecretsManagerFactory.get_hashicorp_manager(vault_url, token, certificate)
+
+    Each factory method handles the instantiation of the appropriate
+    manager class with the required credentials and configuration,
+    providing a centralized way to create secrets manager objects.
+
+    The factory validates required parameters before creating instances
+    and raises appropriate exceptions if credentials are missing or invalid.
+    """
+
+    @staticmethod
+    def get_bitwarden_manager(client_id: str, client_secret: str, master_password: str):
+        """Create a BitwardenManager instance.
+
+        Creates and returns a new BitwardenManager instance using the
+        provided API credentials and master password.
+
+        :param str client_id: Bitwarden API client ID
+        :param str client_secret: Bitwarden API client secret
+        :param str master_password: Master password for unlocking the vault
+
+        :returns: A new BitwardenManager instance
+        :rtype: BitwardenManager
+
+        :raises BitwardenCLIError: If Bitwarden CLI is not found in PATH
+        """
+        from .bw_manager import BitwardenManager
+
+        logger.debug("Creating new Bitwarden manager")
+
+        return BitwardenManager(client_id, client_secret, master_password)
+
+    @staticmethod
+    def get_hashicorp_manager(
+        vault_url: str, token: str, certificate: str | bool = None
+    ):
+        """Create a HashicorpManager instance.
+
+        Creates and returns a new HashicorpManager instance using the
+        provided Vault URL, authentication token, and certificate settings.
+
+        :param str vault_url: The URL of the HashiCorp Vault
+        :param str token: The access token for authentication
+        :param Union[str, bool, None] certificate: TLS verification setting. Either a boolean to indicate whether TLS
+            verification should be performed, a string pointing at the CA bundle to use for
+            verification
+
+        :returns: A new HashicorpManager instance
+        :rtype: HashicorpManager
+
+        :raises HashicorpVaultError: If required credentials cannot be obtained
+        """
+        from .hc_manager import HashicorpManager
+
+        logger.debug("Creating new Hashicorp manager")
+
+        if not all([vault_url, token]):
+           raise HashicorpVaultError("HashiCorp Vault requires vault_url and token")
+
+        return HashicorpManager(vault_url, token, certificate)

--- a/tests/test_resolve_credentials.py
+++ b/tests/test_resolve_credentials.py
@@ -1,0 +1,276 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Grimoirelab Contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Tests for the resolve_credentials function."""
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Mock hvac before importing anything from credential_manager,
+# since the import chain may fail in environments where hvac is not installed.
+sys.modules.setdefault('hvac', MagicMock())
+sys.modules.setdefault('hvac.exceptions', MagicMock())
+
+from grimoirelab_toolkit.credential_manager.credential_manager import (
+    resolve_credentials,
+    _extract_bitwarden_field,
+    _extract_hashicorp_field,
+)
+from grimoirelab_toolkit.credential_manager.exceptions import CredentialNotFoundError
+
+
+class TestExtractBitwardenField(unittest.TestCase):
+    """Tests for _extract_bitwarden_field helper."""
+
+    def test_extract_login_field(self):
+        """Test extracting a field from the login section."""
+        item = {
+            'login': {'username': 'myuser', 'password': 'mypass'},
+            'fields': [],
+        }
+        self.assertEqual(_extract_bitwarden_field(item, 'username'), 'myuser')
+        self.assertEqual(_extract_bitwarden_field(item, 'password'), 'mypass')
+
+    def test_extract_custom_field(self):
+        """Test extracting a custom field from the fields array."""
+        item = {
+            'login': {},
+            'fields': [
+                {'name': 'api_key', 'value': 'tok123'},
+                {'name': 'other', 'value': 'val'},
+            ],
+        }
+        self.assertEqual(_extract_bitwarden_field(item, 'api_key'), 'tok123')
+
+    def test_login_takes_priority_over_custom_field(self):
+        """Test that login fields are checked before custom fields."""
+        item = {
+            'login': {'token': 'login_token'},
+            'fields': [{'name': 'token', 'value': 'custom_token'}],
+        }
+        self.assertEqual(_extract_bitwarden_field(item, 'token'), 'login_token')
+
+    def test_field_not_found(self):
+        """Test that None is returned for missing fields."""
+        item = {'login': {}, 'fields': []}
+        self.assertIsNone(_extract_bitwarden_field(item, 'nonexistent'))
+
+    def test_missing_login_key(self):
+        """Test extraction when 'login' key is missing from item."""
+        item = {'fields': [{'name': 'token', 'value': 'val'}]}
+        self.assertEqual(_extract_bitwarden_field(item, 'token'), 'val')
+
+    def test_missing_fields_key(self):
+        """Test extraction when 'fields' key is missing from item."""
+        item = {'login': {'username': 'user'}}
+        self.assertEqual(_extract_bitwarden_field(item, 'username'), 'user')
+        self.assertIsNone(_extract_bitwarden_field(item, 'nonexistent'))
+
+
+class TestExtractHashicorpField(unittest.TestCase):
+    """Tests for _extract_hashicorp_field helper."""
+
+    def test_extract_field(self):
+        """Test extracting a field from HashiCorp secret structure."""
+        secret = {'data': {'data': {'api_key': 'hc_token', 'user': 'admin'}}}
+        self.assertEqual(_extract_hashicorp_field(secret, 'api_key'), 'hc_token')
+        self.assertEqual(_extract_hashicorp_field(secret, 'user'), 'admin')
+
+    def test_field_not_found(self):
+        """Test that None is returned for missing fields."""
+        secret = {'data': {'data': {'api_key': 'tok'}}}
+        self.assertIsNone(_extract_hashicorp_field(secret, 'nonexistent'))
+
+    def test_missing_data_structure(self):
+        """Test graceful handling of missing nested data keys."""
+        self.assertIsNone(_extract_hashicorp_field({}, 'field'))
+        self.assertIsNone(_extract_hashicorp_field({'data': {}}, 'field'))
+
+
+class TestResolveCredentialsBitwarden(unittest.TestCase):
+    """Tests for resolve_credentials with Bitwarden manager."""
+
+    def setUp(self):
+        self.manager_config = {
+            'client_id': 'cid',
+            'client_secret': 'csecret',
+            'master_password': 'mpass',
+        }
+
+    @patch('grimoirelab_toolkit.credential_manager.credential_manager.SecretsManagerFactory')
+    def test_extract_login_fields(self, mock_factory):
+        """Test resolving login fields (username, password) from Bitwarden."""
+        mock_manager = MagicMock()
+        mock_manager.get_secret.return_value = {
+            'login': {'username': 'myuser', 'password': 'mypass'},
+            'fields': [],
+        }
+        mock_factory.get_bitwarden_manager.return_value = mock_manager
+
+        result = resolve_credentials(
+            'bitwarden',
+            self.manager_config,
+            'my-item',
+            {'username': 'user', 'password': 'password'},
+        )
+
+        self.assertEqual(result, {'user': 'myuser', 'password': 'mypass'})
+        mock_manager.login.assert_called_once()
+        mock_manager.logout.assert_called_once()
+
+    @patch('grimoirelab_toolkit.credential_manager.credential_manager.SecretsManagerFactory')
+    def test_extract_custom_fields(self, mock_factory):
+        """Test resolving custom fields (token) from Bitwarden."""
+        mock_manager = MagicMock()
+        mock_manager.get_secret.return_value = {
+            'login': {},
+            'fields': [{'name': 'api_key', 'value': 'tok123'}],
+        }
+        mock_factory.get_bitwarden_manager.return_value = mock_manager
+
+        result = resolve_credentials(
+            'bitwarden',
+            self.manager_config,
+            'my-item',
+            {'api_key': 'api_token'},
+        )
+
+        self.assertEqual(result, {'api_token': 'tok123'})
+
+    @patch('grimoirelab_toolkit.credential_manager.credential_manager.SecretsManagerFactory')
+    def test_missing_field_omitted(self, mock_factory):
+        """Test that missing fields are omitted from result."""
+        mock_manager = MagicMock()
+        mock_manager.get_secret.return_value = {
+            'login': {'username': 'myuser'},
+            'fields': [],
+        }
+        mock_factory.get_bitwarden_manager.return_value = mock_manager
+
+        result = resolve_credentials(
+            'bitwarden',
+            self.manager_config,
+            'my-item',
+            {'username': 'user', 'nonexistent': 'password'},
+        )
+
+        self.assertEqual(result, {'user': 'myuser'})
+
+    @patch('grimoirelab_toolkit.credential_manager.credential_manager.SecretsManagerFactory')
+    def test_logout_called_on_failure(self, mock_factory):
+        """Test that logout is called even when get_secret fails."""
+        mock_manager = MagicMock()
+        mock_manager.get_secret.side_effect = CredentialNotFoundError("not found")
+        mock_factory.get_bitwarden_manager.return_value = mock_manager
+
+        with self.assertRaises(CredentialNotFoundError):
+            resolve_credentials(
+                'bitwarden',
+                self.manager_config,
+                'my-item',
+                {'username': 'user'},
+            )
+
+        mock_manager.login.assert_called_once()
+        mock_manager.logout.assert_called_once()
+
+
+class TestResolveCredentialsHashicorp(unittest.TestCase):
+    """Tests for resolve_credentials with HashiCorp manager."""
+
+    def setUp(self):
+        self.manager_config = {
+            'vault_url': 'https://vault.example.com',
+            'token': 'hvs.token123',
+            'certificate': '/path/to/cert.pem',
+        }
+
+    @patch('grimoirelab_toolkit.credential_manager.credential_manager.SecretsManagerFactory')
+    def test_extract_fields(self, mock_factory):
+        """Test resolving fields from HashiCorp Vault."""
+        mock_manager = MagicMock()
+        mock_manager.get_secret.return_value = {
+            'data': {'data': {'api_key': 'hc_token', 'user': 'admin'}},
+        }
+        mock_factory.get_hashicorp_manager.return_value = mock_manager
+
+        result = resolve_credentials(
+            'hashicorp',
+            self.manager_config,
+            'secret/my-service',
+            {'api_key': 'api_token', 'user': 'user'},
+        )
+
+        self.assertEqual(result, {'api_token': 'hc_token', 'user': 'admin'})
+
+    @patch('grimoirelab_toolkit.credential_manager.credential_manager.SecretsManagerFactory')
+    def test_missing_field_omitted(self, mock_factory):
+        """Test that missing fields are omitted from result."""
+        mock_manager = MagicMock()
+        mock_manager.get_secret.return_value = {
+            'data': {'data': {'api_key': 'tok'}},
+        }
+        mock_factory.get_hashicorp_manager.return_value = mock_manager
+
+        result = resolve_credentials(
+            'hashicorp',
+            self.manager_config,
+            'secret/path',
+            {'api_key': 'api_token', 'missing': 'password'},
+        )
+
+        self.assertEqual(result, {'api_token': 'tok'})
+
+
+class TestResolveCredentialsGeneral(unittest.TestCase):
+    """Tests for general resolve_credentials behavior."""
+
+    def test_unsupported_manager_type(self):
+        """Test that unsupported manager type raises ValueError."""
+        with self.assertRaises(ValueError):
+            resolve_credentials('unknown', {}, 'item', {'f': 'p'})
+
+    def test_empty_item_name(self):
+        """Test that empty item_name raises ValueError."""
+        with self.assertRaises(ValueError):
+            resolve_credentials('bitwarden', {}, '', {'f': 'p'})
+
+    def test_empty_field_mapping(self):
+        """Test that empty field_mapping returns empty dict without calling manager."""
+        result = resolve_credentials('bitwarden', {}, 'item', {})
+        self.assertEqual(result, {})
+
+    @patch('grimoirelab_toolkit.credential_manager.credential_manager.SecretsManagerFactory')
+    def test_item_not_found_propagates(self, mock_factory):
+        """Test that CredentialNotFoundError from manager propagates."""
+        mock_manager = MagicMock()
+        mock_manager.get_secret.side_effect = CredentialNotFoundError("not found")
+        mock_factory.get_hashicorp_manager.return_value = mock_manager
+
+        with self.assertRaises(CredentialNotFoundError):
+            resolve_credentials(
+                'hashicorp',
+                {'vault_url': 'url', 'token': 'tok'},
+                'missing/path',
+                {'field': 'param'},
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add a framework-agnostic resolve_credentials() function that fetches and extracts credentials from Bitwarden or HashiCorp Vault in a single call. This allows any caller (BackendCommand, KingArthur, scripts) to resolve secrets without depending on Perceval's CLI layer.

The objective of this changes is to allow for the proper integration with Perceval and other parts of grimoirelab so they can use credential_manager as a standalone library.

- Add resolve_credentials() with field extraction helpers
- Add SecretsManagerFactory for lazy manager instantiation
- Export resolve_credentials and HashicorpVaultError from package
- Add tests for all credential resolution paths
- Document usage in README